### PR TITLE
added param slope for conv to fuse with prelu

### DIFF
--- a/include/ppl/kernel/arm_server/conv2d/neon/conv2d.h
+++ b/include/ppl/kernel/arm_server/conv2d/neon/conv2d.h
@@ -152,6 +152,7 @@ protected:
     void *dst_;
     const ppl::common::TensorShape *dst_shape_;
     void *sum_;
+    void *slope_;
     void *temp_buffer_;
 
 public:
@@ -164,6 +165,7 @@ public:
         , dst_(nullptr)
         , dst_shape_(nullptr)
         , sum_(nullptr)
+        , slope_(nullptr)
         , temp_buffer_(nullptr) {}
 
     conv2d_runtime_executor(const conv2d_param *conv_param, const void *cvt_filter, const void *cvt_bias)
@@ -175,6 +177,7 @@ public:
         , dst_(nullptr)
         , dst_shape_(nullptr)
         , sum_(nullptr)
+        , slope_(nullptr)
         , temp_buffer_(nullptr) {}
 
     virtual uint64_t cal_temp_buffer_size() = 0;
@@ -262,6 +265,15 @@ public:
     void *sum() const
     {
         return sum_;
+    }
+
+    void set_slope(void *slope)
+    {
+        slope_ = slope;
+    }
+    void *slope() const
+    {
+        return slope_;
     }
 
     void set_temp_buffer(void *temp_buffer)


### PR DESCRIPTION
PReLu has a parameter slope. In order to support the fusion of conv and prelu, a slope parameter needs to be added to conv. Modified the constructor of conv2d runtime executor, and the getter and setter of slope.